### PR TITLE
Cambiado la palabra cambos por cambios

### DIFF
--- a/lab_07.html
+++ b/lab_07.html
@@ -41,7 +41,7 @@
   <div id="main_content">
     <h1 class="lab_title"><em>lab 7</em>  Staging y Commit</h1>
 <p>Un paso separado del concepto de Staging está alineado con la filosofía de "salirse del camino" hasta que se necesite hacer frente al control de código fuente. Puede continuar haciendo cambios en su directorio de trabajo, y entonces, en el punto en que quiera interactuar con el control de código fuente, git le permitirá grabar los cambios en pequeños Commits que reproducirán exactamente lo que hizo.</p>
-<p>Por ejemplo, suponga que quiere editar tres archivos: <code>a.rb</code>, <code>b.rb</code>, and <code>c.rb</code>. Ahora desea hacer Commit de todos los cambos, pero desea que los cambios en <code>a.rb</code> y <code>b.rb</code> estén en un Commit, mientras que los cambios de <code>c.rb</code> no están relacionados lógicamente con los primeros dos archivos y debería estar en un Commit separado.</p>
+<p>Por ejemplo, suponga que quiere editar tres archivos: <code>a.rb</code>, <code>b.rb</code>, and <code>c.rb</code>. Ahora desea hacer Commit de todos los cambios, pero desea que los cambios en <code>a.rb</code> y <code>b.rb</code> estén en un Commit, mientras que los cambios de <code>c.rb</code> no están relacionados lógicamente con los primeros dos archivos y debería estar en un Commit separado.</p>
 <p>Puede realizar lo siguiente:</p>
 <pre class="instructions">git add a.rb
 git add b.rb


### PR DESCRIPTION
Se ha cambiado la palabra "cambos" por "cambios" en uno de los parrafos de la lección 7.